### PR TITLE
Escape `-` in MarkdownV2 escape regex

### DIFF
--- a/source/markdownv2.ts
+++ b/source/markdownv2.ts
@@ -7,7 +7,7 @@ function escapeInteral(text: string, escapeChars: string): string {
 }
 
 function escape(text: string): string {
-	return text.replace(/[_*[\]()~`>#+-=|{}.!]/g, '\\$&')
+	return text.replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&')
 }
 
 function bold(text: string): string {


### PR DESCRIPTION
Without escaping, the regex matches numbers as well.