### PR TITLE
Bugfix escape function for markdown

### DIFF
--- a/source/markdown.ts
+++ b/source/markdown.ts
@@ -3,7 +3,7 @@
 import {Formatter} from './interface'
 
 function escape(text: string): string {
-	return text.replace(/[*_`[\]()]/g, '')
+	return text.replace(/[*_`[\]]/g, '\\$&')
 }
 
 function bold(text: string): string {

--- a/test/markdown.ts
+++ b/test/markdown.ts
@@ -15,7 +15,7 @@ test('url', t => {
 })
 
 test('escape', t => {
-	t.is(format.escape('[h_]e(*y)`'), 'hey')
+	t.is(format.escape('[h_]e*y`'), '\\[h\\_\\]e\\*y\\`')
 })
 
 test('bold malicious', t => {


### PR DESCRIPTION
Following notes from the official documentation, we need to escape using another way. Bugfix into the pull request.

![image](https://user-images.githubusercontent.com/54890287/104653303-7539bc80-56cb-11eb-8df4-150dacea2e2f.png)
