### PR TITLE
fix Markdownv2 character '\' is not escaped

### DIFF
--- a/source/markdownv2.ts
+++ b/source/markdownv2.ts
@@ -7,7 +7,7 @@ function escapeInteral(text: string, escapeChars: string): string {
 }
 
 function escape(text: string): string {
-	return text.replace(/[_*[\]()~`>#+\-=|{}.!]/g, '\\$&')
+	return text.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, '\\$&')
 }
 
 function bold(text: string): string {

--- a/test/markdownv2.ts
+++ b/test/markdownv2.ts
@@ -23,7 +23,7 @@ test('url', t => {
 })
 
 test('escape', t => {
-	t.is(format.escape('[h_]e(*y)`'), '\\[h\\_\\]e\\(\\*y\\)\\`')
+	t.is(format.escape('[h_]e(*y\\)`'), '\\[h\\_\\]e\\(\\*y\\\\\\)\\`')
 })
 
 test('escape with number', t => {


### PR DESCRIPTION
Fixed bug. I think everything is clear from the title and pic

![изображение_2021-04-03_173407](https://user-images.githubusercontent.com/44119743/113481536-ca06fb00-94a2-11eb-8483-8d19037e3275.png)
